### PR TITLE
Note collapse and bug highlighting styles fail on GitLab 18.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -497,17 +497,17 @@
   }
 
   GM_addStyle(`
-  .notes .note .timeline-content.collapse-item {
+  .notes .note.collapse-item .timeline-content {
     height: 100px;
     background-color: #67c23a;
     overflow: hidden;
   }
 
-  .notes .note .timeline-content.collapse-item * {
+  .notes .note.collapse-item .timeline-content * {
     background-color: #67c23a;
   }
 
-  .notes-list .note .timeline-content.highest-level-bug:not(.collapse-item) {
+  .notes-list .note.highest-level-bug:not(.collapse-item) .timeline-content {
     background: #f56c6c;
   }
 


### PR DESCRIPTION
Closes #7. This PR fixes the visual styling issues on GitLab 18.x by updating CSS selectors for note collapse and high-priority bug highlighting.